### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 * Fork this repository.
 * `$ git clone git@github.com:<your username>/thinkster-django-angular-boilerplate.git`
-* `$ mkvirtualenv thinkster-djangular`
+* `$ mkvirtualenv --python=/bin/python2.7 thinkster-djangular`
 * `$ cd thinkster-django-angular-boilerplate/`
 * `$ pip install -r requirements.txt`
 * `$ npm install -g bower`


### PR DESCRIPTION
when installing requirements wsgiref can not be installed using python 3, so I had to create the virtual environment specifying python 2.7 because I am using python 3 in my system and it is the default. I think that making explicit the use of python 2.7 can avoid troubles to some people using python 3.